### PR TITLE
always use PROD mode

### DIFF
--- a/build.js
+++ b/build.js
@@ -9,7 +9,6 @@
 
 var PORT            = process.env.PORT || 9999;
 var IS_PROD         = process.env.NODE_ENV === 'prod';
-var KEEP_PROD_ALIVE = process.env.SERVE_PROD;
 var SHOW_DRAFTS     = process.env.SHOW_DRAFTS;
 var Metalsmith      = require('metalsmith');
 var markdown        = require('metalsmith-markdown');
@@ -30,18 +29,6 @@ var wordCount       = require('metalsmith-word-count');
 var fs              = require('fs-extra');
 
 var M = Metalsmith(__dirname);
-
-if (!IS_PROD) {
-    M.use(watch(
-        {
-            paths: {
-                "${source}/**/*": "**/*",
-                "_templates/**/*": "**/*"
-            },
-            livereload: true
-        }
-    ));
-}
 
 if (!SHOW_DRAFTS) {
     // remove any article with the `draft: true` YFM
@@ -65,6 +52,15 @@ M.metadata({
     // .clean(false)
     // .destination('.')
     .destination('./_build')
+    .use(watch(
+        {
+            paths: {
+                "${source}/**/*": "**/*",
+                "_templates/**/*": "**/*"
+            },
+            livereload: true
+        }
+    ))
     .use(wordCount())
     .use(markdown({
         smartypants: true,
@@ -125,17 +121,11 @@ M.metadata({
         }
         console.log('built');
 
-        if (IS_PROD) {
-            fs.copy('./_build', './', function(err) {
-                if (err) {
-                    return console.error(err);
-                }
-                console.log('moved _build content');
-                if (!KEEP_PROD_ALIVE) {
-                    console.log('exiting')
-                    process.exit();
-                }
-            });
-        }
+        fs.copy('./_build', './', function(err) {
+            if (err) {
+                return console.error(err);
+            }
+            console.log('moved _build content');
+        });
     });
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node build",
+    "start": "NODE_ENV=prod node build",
     "build": "NODE_ENV=prod npm start",
     "serve-build": "SERVE_PROD=true npm run build",
     "show-drafts": "SHOW_DRAFTS=true node build"


### PR DESCRIPTION
always publish in PROD mode so that any sort of markdown updates will be published and brought to the author's attention when modifying posts.

Putting it into PROD mode is relatively simple. The trickier part is always getting the `.build` step to run which still needs to be looked into.

Current plugin used to watch file changes: https://github.com/FWeinb/metalsmith-watch
potential plugin that could help: https://github.com/pjeby/gulpsmith
